### PR TITLE
Add IP range whitelist

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -124,6 +124,10 @@ Resources:
       Name: !Sub ${AWS::StackName}-secure-fraud-site-api
       StageName: default
       TracingEnabled: true
+      GatewayResponses:
+        ACCESS_DENIED:
+           ResponseTemplates: 
+              application/json: '{"message": "Access Denied: if you think you should have access to this URL, make sure you are connected to the VPN"}'
       Auth:
         ResourcePolicy:
           IpRangeWhitelist:

--- a/template.yaml
+++ b/template.yaml
@@ -124,6 +124,21 @@ Resources:
       Name: !Sub ${AWS::StackName}-secure-fraud-site-api
       StageName: default
       TracingEnabled: true
+      Auth:
+        ResourcePolicy:
+          IpRangeWhitelist:
+             - '{{resolve:ssm:SECURE_DOWNLOAD_WEBSITE_ALLOWED_IP_1}}'
+             - '{{resolve:ssm:SECURE_DOWNLOAD_WEBSITE_ALLOWED_IP_2}}'
+             - '{{resolve:ssm:SECURE_DOWNLOAD_WEBSITE_ALLOWED_IP_3}}'
+             - '{{resolve:ssm:SECURE_DOWNLOAD_WEBSITE_ALLOWED_IP_4}}'
+             - '{{resolve:ssm:SECURE_DOWNLOAD_WEBSITE_ALLOWED_IP_5}}'
+             - '{{resolve:ssm:SECURE_DOWNLOAD_WEBSITE_ALLOWED_IP_6}}'
+             - '{{resolve:ssm:SECURE_DOWNLOAD_WEBSITE_ALLOWED_IP_7}}'
+             - '{{resolve:ssm:SECURE_DOWNLOAD_WEBSITE_ALLOWED_IP_8}}'
+             - '{{resolve:ssm:SECURE_DOWNLOAD_WEBSITE_ALLOWED_IP_9}}'
+             - '{{resolve:ssm:SECURE_DOWNLOAD_WEBSITE_ALLOWED_IP_10}}'
+             - '{{resolve:ssm:SECURE_DOWNLOAD_WEBSITE_ALLOWED_IP_11}}'
+             - '{{resolve:ssm:SECURE_DOWNLOAD_WEBSITE_ALLOWED_IP_12}}'
 
   SecureFraudSiteAccessLogGroup:
     Type: AWS::Logs::LogGroup


### PR DESCRIPTION
We have a requirement to restrict access to the download website so that only users on the GDS VPN can access it.

This is driven by a series of SSM parameters.

It didn't seem to be possible to use a single parameter and comma-split it (see discussion on this here, the suggested solutions didn't seem to work https://github.com/aws/aws-cdk/issues/19349) so we've hard-coded the specific parameters and number of IPs.

If we need to white-list another IP in future, we'll need to adjust the template and add a new parameter