### PR TITLE
Cleanup pipeline triggers and job conditions

### DIFF
--- a/.github/workflows/build-test-package.yaml
+++ b/.github/workflows/build-test-package.yaml
@@ -1,9 +1,6 @@
 name: Build, Test and Package
 
 on:
-  pull_request:
-    branches:
-      - main
   push:
     branches:
       - main
@@ -11,12 +8,11 @@ on:
   workflow_dispatch: {}
 
 env:
-  REGION: eu-west-2
+  AWS_REGION: eu-west-2
 
 jobs:
-  build-test-and-validate:
-    name: Run tests and validation
-    if: github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+  validate-build:
+    name: Validate build & run tests
     permissions:
       id-token: write
       contents: read
@@ -24,7 +20,7 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
-      - name: Setup Python
+      - name: Setup Python 3.8
         uses: actions/setup-python@v3
         with:
           python-version: '3.8'
@@ -33,7 +29,7 @@ jobs:
       - name: Assume AWS Validate role
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-region: ${{ env.REGION }}
+          aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets.GH_ACTIONS_VALIDATE_ROLE_ARN }}
       - name: Node - Enable Corepack
         run: corepack enable
@@ -45,19 +41,18 @@ jobs:
       - name: Run tests
         if: always()
         run: yarn test
-      - name: Build Lambda functions
-        if: always()
-        run: yarn build
       - name: Validate SAM template
         if: always()
-        run: sam validate --config-env build
+        run: sam validate
       - name: Run Checkov on SAM template
         if: always()
         uses: bridgecrewio/checkov-action@master
         with:
-          file: template.yaml
-          quiet: true
+          directory: '.'
           framework: cloudformation
+          quiet: true
+      - name: Build Lambda functions
+        run: yarn build
       - name: Upload build artifact
         uses: actions/upload-artifact@v3
         with:
@@ -69,7 +64,6 @@ jobs:
 
   check-yarn-cache:
     name: Check Yarn cache
-    if: github.event_name == 'pull_request' || (github.ref == 'refs/heads/main' && github.event_name == 'push')
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
@@ -82,9 +76,9 @@ jobs:
         run: yarn install --immutable --immutable-cache --check-cache
 
   deploy-feature:
-    name: Deploy feature branch
-    if: startsWith(github.ref, 'refs/heads/feature') || github.event_name == 'workflow_dispatch'
-    needs: [build-test-and-validate]
+    name: Deploy feature branch to dev account
+    if: startsWith(github.ref, 'refs/heads/feature') || (github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main')
+    needs: [validate-build]
     permissions:
       id-token: write
       contents: read
@@ -94,7 +88,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: sam-build
-      - name: Setup Python
+      - name: Setup Python 3.8
         uses: actions/setup-python@v3
         with:
           python-version: '3.8'
@@ -103,24 +97,29 @@ jobs:
       - name: Assume the dev account deployment role
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-region: ${{ env.REGION }}
+          aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets.GH_ACTIONS_DEV_DEPLOY_ROLE_ARN }}
       - name: Deploy to feature stack in the dev account
         env:
-          DEV_ARTIFACT_BUCKET: ${{ secrets.DEV_ARTIFACT_BUCKET }}
           FEATURE_BRANCH_NAME: ${{ github.event.ref }}
         run: |
-          stack_name=$(echo ${FEATURE_BRANCH_NAME##*/} | tr -cd '[a-zA-Z0-9-]' | tr '[:upper:]' '[:lower:]')
+          stack_name=$(
+            echo ${FEATURE_BRANCH_NAME##*/} | \
+            tr -cd '[a-zA-Z0-9-]' | \
+            tr '[:upper:]' '[:lower:]' | \
+            cut -c -32
+          )
+
           sam deploy \
             --config-env dev \
-            --stack-name ${stack_name:0:32} \
+            --stack-name ${stack_name} \
             --no-fail-on-empty-changeset \
-            --s3-bucket ${DEV_ARTIFACT_BUCKET}
+            --resolve-s3
 
-  package-artifacts:
-    name: Package artifacts for deployment
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: [build-test-and-validate, check-yarn-cache]
+  package-build:
+    name: Package for deployment to build account
+    if: github.ref == 'refs/heads/main'
+    needs: [validate-build, check-yarn-cache]
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -130,7 +129,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: sam-build
-      - name: Setup Python
+      - name: Setup Python 3.8
         uses: actions/setup-python@v3
         with:
           python-version: '3.8'
@@ -139,9 +138,9 @@ jobs:
       - name: Assume AWS role
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-region: ${{ env.REGION }}
+          aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
-      - name: Package SAM app
+      - name: Package SAM app and upload to S3
         uses: alphagov/di-devplatform-upload-action@v2
         with:
           artifact-bucket-name: ${{ secrets.ARTIFACT_BUCKET_NAME }}

--- a/.github/workflows/build-test-package.yaml
+++ b/.github/workflows/build-test-package.yaml
@@ -1,11 +1,6 @@
 name: Build, Test and Package
 
-on:
-  push:
-    branches:
-      - main
-      - feature**
-  workflow_dispatch: {}
+on: [push, workflow_dispatch]
 
 env:
   AWS_REGION: eu-west-2

--- a/.github/workflows/delete-feature-branch.yaml
+++ b/.github/workflows/delete-feature-branch.yaml
@@ -2,23 +2,22 @@ name: Delete feature branch stack
 
 on:
   delete:
-    branches:
-      - feature**
+    branches-ignore:
+      - main
 
 env:
-  REGION: eu-west-2
+  AWS_REGION: eu-west-2
 
 jobs:
   delete-feature:
     name: Delete feature branch
-    if: startsWith(github.event.ref, 'feature') && github.event_name == 'delete'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read
     steps:
       - uses: actions/checkout@v2
-      - name: Setup Python
+      - name: Setup Python 3.8
         uses: actions/setup-python@v3
         with:
           python-version: '3.8'
@@ -27,14 +26,20 @@ jobs:
       - name: Assume the dev account deployment role
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-region: ${{ env.REGION }}
+          aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets.GH_ACTIONS_DEV_DEPLOY_ROLE_ARN }}
       - name: Delete feature branch stack
         env:
           FEATURE_BRANCH_NAME: ${{ github.event.ref }}
         run: |
-          stack_name=$(echo ${FEATURE_BRANCH_NAME##*/} | tr -cd '[a-zA-Z0-9-]' | tr '[:upper:]' '[:lower:]')
+          stack_name=$(
+            echo ${FEATURE_BRANCH_NAME##*/} | \
+            tr -cd '[a-zA-Z0-9-]' | \
+            tr '[:upper:]' '[:lower:]' | \
+            cut -c -32
+          )
+
           sam delete \
-            --stack-name ${stack_name:0:32} \
-            --region ${REGION} \
+            --stack-name ${stack_name} \
+            --region ${AWS_REGION} \
             --no-prompts

--- a/samconfig.toml
+++ b/samconfig.toml
@@ -2,18 +2,10 @@ version = 0.1
 
 [dev.deploy.parameters]
 region = "eu-west-2"
-stack_name = "ticf-integration"
-tags = "project=\"di-txma-ticf-integration\" stage=\"dev\""
+tags = "Product=\"GOV.UK Sign In\" System=\"TxMA\" Environment=\"dev\" Owner=\"di-txma-team-2@digital.cabinet-office.gov.uk\""
 capabilities = "CAPABILITY_NAMED_IAM"
 parameter_overrides=[
     "Environment=dev",
     "CodeSigningConfigArn=none",
     "PermissionsBoundary=none"
-]
-
-[build.validate.parameters]
-region = "eu-west-2"
-stack_name = "ticf-integration"
-parameter_overrides=[
-    "Environment=build"
 ]


### PR DESCRIPTION
* The Check Yarn cache job takes approx the same time to complete as the validate/run tests job. Since they run in parallel, decided it was better to run this job on all pushes instead of just PRs. This lets us remove the PR trigger and just have push triggers and avoid duplicate jobs running when PRs are opened.
* This lets us clean up the trigger conditions on other jobs
* Removed the `build` configuration from `samconfig.toml` as this was never used
* Removed the Dev S3 bucket from the deploy feature branch job. Instead we pass a `--resolve-s3` flag, which will create a SAM managed S3 bucket for us, and use an existing one if it already exists