### PR TITLE
test/tt2-167-make-int-tests-environment-specific

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,6 @@ node_modules/
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
-.integration.test.env
+.integration.test-dev.env
+.integration.test-build.env
+.integration.test-staging.env

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,4 @@ node_modules/
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
-.integration.test-dev.env
-.integration.test-build.env
-.integration.test-staging.env
+.integration.test-*.env

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This is an API Gateway, 2 AWS Lambda functions, a DynamoDB table and an S3 bucke
 
 As well as the usual unit tests, we have some tests which hit the deployed Lambdas, and also set up some test data so that those tests have what they need.
 
-To get started with those, you need to create a file called `.integration.test.env` at the root, with the following contents (adjust as necessary)
+To get started with those, you need to create a file called `.integration.test-<<environment>>.env` (where `environment` is the desired test environment - one of `dev`, `build`, and `staging`) at the root, with the following contents (adjust as necessary)
 
 ```
 process.env.DOWNLOAD_PAGE_BASE_URL="https://YOUR-LAMBDA-URL.amazonaws.com/default/"

--- a/jest.integration.config.ts
+++ b/jest.integration.config.ts
@@ -4,7 +4,7 @@ const config: Config.InitialOptions = {
   coveragePathIgnorePatterns: ['/node_modules/', '/dist/'],
   testPathIgnorePatterns: ['/src/'],
   preset: 'ts-jest',
-  setupFiles: ['<rootDir>/.integration.test.env'],
+  setupFiles: ['<rootDir>/.integration.test-dev.env'],
   verbose: true
 }
 

--- a/jest.integration.config.ts
+++ b/jest.integration.config.ts
@@ -4,7 +4,7 @@ const config: Config.InitialOptions = {
   coveragePathIgnorePatterns: ['/node_modules/', '/dist/'],
   testPathIgnorePatterns: ['/src/'],
   preset: 'ts-jest',
-  setupFiles: ['<rootDir>/.integration.test-dev.env'],
+  setupFiles: ['<rootDir>/.integration.test-build.env'],
   verbose: true
 }
 

--- a/jest.integration.config.ts
+++ b/jest.integration.config.ts
@@ -4,7 +4,6 @@ const config: Config.InitialOptions = {
   coveragePathIgnorePatterns: ['/node_modules/', '/dist/'],
   testPathIgnorePatterns: ['/src/'],
   preset: 'ts-jest',
-  setupFiles: ['<rootDir>/.integration.test-build.env'],
   verbose: true
 }
 

--- a/package.json
+++ b/package.json
@@ -16,9 +16,7 @@
     "postinstall": "husky install",
     "prepare": "node -e \"try { require('husky').install() } catch (e) {if (e.code !== 'MODULE_NOT_FOUND') throw e}\"",
     "test": "jest -c jest.config.ts",
-    "test:integration-dev": "jest --setupFiles ./.integration.test-dev.env -c jest.integration.config.ts",
-    "test:integration-build": "jest --setupFiles ./.integration.test-build.env -c jest.integration.config.ts",
-    "test:integration-staging": "jest --setupFiles ./.integration.test-staging.dev -c jest.integration.config.ts"
+    "test:integration-dev": "jest --setupFiles ./.integration.test-${ENV}.env -c jest.integration.config.ts"
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "3.186.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "postinstall": "husky install",
     "prepare": "node -e \"try { require('husky').install() } catch (e) {if (e.code !== 'MODULE_NOT_FOUND') throw e}\"",
     "test": "jest -c jest.config.ts",
-    "test:integration": "jest -c jest.integration.config.ts"
+    "test:integration-dev": "jest --setupFiles ./.integration.test-dev.env -c jest.integration.config.ts",
+    "test:integration-build": "jest --setupFiles ./.integration.test-build.env -c jest.integration.config.ts",
+    "test:integration-staging": "jest --setupFiles ./.integration.test-staging.dev -c jest.integration.config.ts"
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "3.186.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "postinstall": "husky install",
     "prepare": "node -e \"try { require('husky').install() } catch (e) {if (e.code !== 'MODULE_NOT_FOUND') throw e}\"",
     "test": "jest -c jest.config.ts",
-    "test:integration-dev": "jest --setupFiles ./.integration.test-${ENV}.env -c jest.integration.config.ts"
+    "test:integration": "jest --setupFiles ./.integration.test-${ENV}.env -c jest.integration.config.ts"
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "3.186.0",


### PR DESCRIPTION
Config changes to make the integration tests run against the different test environments.

- Updating jest.integration.config.ts to use dev by default
- Scripts for dev, build, and staging.
- Updated README.