### PR TITLE
Add test role parameter and condition

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -23,11 +23,16 @@ Parameters:
   SecureDownloadWebsiteAllowedIps:
     Type: AWS::SSM::Parameter::Value<List<String>>
     Default: SecureDownloadWebsiteAllowedIps
+  TestRoleArn:
+    Type: String
+    Description: The ARN of the role that will used for integration tests
+    Default: none
 
 Conditions:
   ApiCustomDomain: !Not [!Equals [!Ref Environment, dev]]
   UseCodeSigning: !Not [!Equals [!Ref CodeSigningConfigArn, none]]
   UsePermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, none]]
+  TestRolePolicy: !Not [!Equals [!Ref TestRoleArn, none]]
 
 Globals:
   Function:


### PR DESCRIPTION
- Adds a parameter for `TestRoleArn` which is populated by the pipeline
- Add condition that can be used on resource based policies to determine whether or not to deploy a policy statement for the test role