### PR TITLE
Feature/move generate download role

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -372,7 +372,7 @@ Resources:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: !GetAtt GenerateDownloadFunctionLogs.Arn
-              - Sid: AllowQueueRead
+              - Sid: AllowQueryCompletedQueueRead
                 Effect: Allow
                 Action:
                   - sqs:ReceiveMessage
@@ -394,13 +394,13 @@ Resources:
                 Action:
                   - s3:PutObject
                 Resource: '{{resolve:ssm:QueryResultsBucketArn}}/*'
-              - Sid: AllowSqsSend
+              - Sid: AllowSqsSendToEmailQueue
                 Effect: Allow
                 Action:
                   - sqs:SendMessage
                 Resource:
                   - !GetAtt SendEmailQueue.Arn
-              - Sid: UseSqsKmsKey
+              - Sid: UseSQSKmsKeyForSendToEmailQueue
                 Effect: Allow
                 Action:
                   - kms:Decrypt

--- a/template.yaml
+++ b/template.yaml
@@ -379,19 +379,12 @@ Resources:
                   - sqs:DeleteMessage
                   - sqs:GetQueueAttributes
                 Resource: !Sub 'arn:aws:sqs:${AWS::Region}:{{resolve:ssm:AuditAccountNumber}}:txma-data-analysis-${Environment}-query-completed-queue'
-              - Sid: UseQueryCompletedQueueKmsKey
-                Effect: Allow
-                Action:
-                  - kms:Decrypt
-                  - kms:GenerateDataKey*
-                  - kms:ReEncrypt*
-                Resource: !Sub 'arn:aws:kms:${AWS::Region}:{{resolve:ssm:AuditAccountNumber}}:*'
               - Sid: AllowAccessAthenaOutputBucket
                 Effect: Allow
                 Action:
                   - s3:GetObject
                 Resource: !Sub 'arn:aws:s3:::txma-data-analysis-${Environment}-athena-query-output-bucket/*'
-              - Sid: AllowDecryptOfAthenaOutput
+              - Sid: AllowDecryptOfAuditAccountKmsKeys
                 Effect: Allow
                 Action:
                   - kms:Decrypt
@@ -411,6 +404,5 @@ Resources:
                 Effect: Allow
                 Action:
                   - kms:Decrypt
-                  - kms:GenerateDataKey*
-                  - kms:ReEncrypt*
+                  - kms:GenerateDataKey
                 Resource: '{{resolve:ssm:SqsKmsKeyArn}}'

--- a/template.yaml
+++ b/template.yaml
@@ -271,6 +271,7 @@ Resources:
       #checkov:skip=CKV_AWS_116:Queue we read from has DLQ set up
       Type: AWS::Serverless::Function
       Properties:
+        Role: !GetAtt GenerateDownloadFunctionRole.Arn
         Handler: generateDownload.handler
         Environment:
           Variables:
@@ -287,70 +288,93 @@ Resources:
               BatchSize: 1
         FunctionName: !Sub ${AWS::StackName}-generate-download
         KmsKeyArn: '{{resolve:ssm:LambdaKmsKeyArn}}'
-        Policies:
-          - Statement:
-            - Sid: SecureFraudSiteDataTableWrite
-              Effect: Allow
-              Action:
-                - dynamodb:PutItem
-              Resource: '{{resolve:ssm:SecureFraudSiteDataTableArn}}'
-            - Sid: DecryptDatabaseKmsKey
-              Effect: Allow
-              Action:
-                - kms:Decrypt
-              Resource: '{{resolve:ssm:DatabaseKmsKeyArn}}'
-            - Sid: Logs
-              Effect: Allow
-              Action:
-                - logs:CreateLogGroup
-                - logs:CreateLogStream
-                - logs:PutLogEvents
-              Resource: !GetAtt DownloadWarningFunctionLogs.Arn
-            - Sid: AllowQueueRead
-              Effect: Allow
-              Action:
-                - sqs:ReceiveMessage
-                - sqs:DeleteMessage
-                - sqs:GetQueueAttributes
-              Resource: !Sub 'arn:aws:sqs:${AWS::Region}:{{resolve:ssm:AuditAccountNumber}}:txma-data-analysis-${Environment}-query-completed-queue'
-            - Sid: UseQueryCompletedQueueKmsKey
-              Effect: Allow
-              Action:
-                - kms:Decrypt
-                - kms:GenerateDataKey*
-                - kms:ReEncrypt*
-              Resource: !Sub 'arn:aws:kms:${AWS::Region}:{{resolve:ssm:AuditAccountNumber}}:*'
-            - Sid: AllowAccessAthenaOutputBucket
-              Effect: Allow
-              Action:
-                - s3:GetObject
-              Resource: !Sub 'arn:aws:s3:::txma-data-analysis-${Environment}-athena-query-output-bucket/*'
-            - Sid: AllowDecryptOfAthenaOutput
-              Effect: Allow
-              Action:
-                - kms:Decrypt
-              Resource: !Sub 'arn:aws:kms:${AWS::Region}:{{resolve:ssm:AuditAccountNumber}}:*'
-            - Sid: S3ResultsBucketWrite
-              Effect: Allow
-              Action:
-                - s3:PutObject
-              Resource: '{{resolve:ssm:QueryResultsBucketArn}}/*'
-            - Sid: AllowSqsSend
-              Effect: Allow
-              Action:
-                - sqs:SendMessage
-              Resource:
-                - !GetAtt SendEmailQueue.Arn
-            - Sid: UseSqsKmsKey
-              Effect: Allow
-              Action:
-                - kms:Decrypt
-                - kms:GenerateDataKey*
-                - kms:ReEncrypt*
-              Resource: '{{resolve:ssm:SqsKmsKeyArn}}'
+
   GenerateDownloadFunctionLogs:
     Type: AWS::Logs::LogGroup
     Properties:
       KmsKeyId: '{{resolve:ssm:LogsKmsKeyArn}}'
       LogGroupName: !Sub '/aws/lambda/${AWS::StackName}-generate-download'
       RetentionInDays: 30
+
+  GenerateDownloadFunctionRole:
+      Type: AWS::IAM::Role
+      Properties:
+        RoleName: !Sub ${AWS::StackName}-generate-download-role
+        PermissionsBoundary:
+          !If [
+            UsePermissionsBoundary,
+            !Ref PermissionsBoundary,
+            !Ref AWS::NoValue
+          ]
+        AssumeRolePolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+            - Effect: Allow
+              Principal:
+                Service:
+                  - lambda.amazonaws.com
+              Action: sts:AssumeRole
+        Policies:
+          - PolicyName: AllowRequiredLambdaActions
+            PolicyDocument:
+              Version: '2012-10-17'
+              Statement:
+                - Sid: SecureFraudSiteDataTableWrite
+                  Effect: Allow
+                  Action:
+                    - dynamodb:PutItem
+                  Resource: '{{resolve:ssm:SecureFraudSiteDataTableArn}}'
+                - Sid: DecryptDatabaseKmsKey
+                  Effect: Allow
+                  Action:
+                    - kms:Decrypt
+                  Resource: '{{resolve:ssm:DatabaseKmsKeyArn}}'
+                - Sid: Logs
+                  Effect: Allow
+                  Action:
+                    - logs:CreateLogGroup
+                    - logs:CreateLogStream
+                    - logs:PutLogEvents
+                  Resource: !GetAtt DownloadWarningFunctionLogs.Arn
+                - Sid: AllowQueueRead
+                  Effect: Allow
+                  Action:
+                    - sqs:ReceiveMessage
+                    - sqs:DeleteMessage
+                    - sqs:GetQueueAttributes
+                  Resource: !Sub 'arn:aws:sqs:${AWS::Region}:{{resolve:ssm:AuditAccountNumber}}:txma-data-analysis-${Environment}-query-completed-queue'
+                - Sid: UseQueryCompletedQueueKmsKey
+                  Effect: Allow
+                  Action:
+                    - kms:Decrypt
+                    - kms:GenerateDataKey*
+                    - kms:ReEncrypt*
+                  Resource: !Sub 'arn:aws:kms:${AWS::Region}:{{resolve:ssm:AuditAccountNumber}}:*'
+                - Sid: AllowAccessAthenaOutputBucket
+                  Effect: Allow
+                  Action:
+                    - s3:GetObject
+                  Resource: !Sub 'arn:aws:s3:::txma-data-analysis-${Environment}-athena-query-output-bucket/*'
+                - Sid: AllowDecryptOfAthenaOutput
+                  Effect: Allow
+                  Action:
+                    - kms:Decrypt
+                  Resource: !Sub 'arn:aws:kms:${AWS::Region}:{{resolve:ssm:AuditAccountNumber}}:*'
+                - Sid: S3ResultsBucketWrite
+                  Effect: Allow
+                  Action:
+                    - s3:PutObject
+                  Resource: '{{resolve:ssm:QueryResultsBucketArn}}/*'
+                - Sid: AllowSqsSend
+                  Effect: Allow
+                  Action:
+                    - sqs:SendMessage
+                  Resource:
+                    - !GetAtt SendEmailQueue.Arn
+                - Sid: UseSqsKmsKey
+                  Effect: Allow
+                  Action:
+                    - kms:Decrypt
+                    - kms:GenerateDataKey*
+                    - kms:ReEncrypt*
+                  Resource: '{{resolve:ssm:SqsKmsKeyArn}}'

--- a/template.yaml
+++ b/template.yaml
@@ -288,7 +288,7 @@ Resources:
               BatchSize: 1
         FunctionName: !Sub ${AWS::StackName}-generate-download
         KmsKeyArn: '{{resolve:ssm:LambdaKmsKeyArn}}'
-
+                  
   GenerateDownloadFunctionLogs:
     Type: AWS::Logs::LogGroup
     Properties:
@@ -299,7 +299,7 @@ Resources:
   GenerateDownloadFunctionRole:
       Type: AWS::IAM::Role
       Properties:
-        RoleName: !Sub ${AWS::StackName}-generate-download-role
+        RoleName: !Sub ${AWS::StackName}-${Environment}-generate-download-role
         PermissionsBoundary:
           !If [
             UsePermissionsBoundary,
@@ -315,7 +315,7 @@ Resources:
                   - lambda.amazonaws.com
               Action: sts:AssumeRole
         Policies:
-          - PolicyName: AllowRequiredLambdaActions
+          - PolicyName: AllowGenerateDownloadActions
             PolicyDocument:
               Version: '2012-10-17'
               Statement:
@@ -335,7 +335,7 @@ Resources:
                     - logs:CreateLogGroup
                     - logs:CreateLogStream
                     - logs:PutLogEvents
-                  Resource: !GetAtt DownloadWarningFunctionLogs.Arn
+                  Resource: !GetAtt GenerateDownloadFunctionLogs.Arn
                 - Sid: AllowQueueRead
                   Effect: Allow
                   Action:


### PR DESCRIPTION
As part of TT2-170, we need to have a named role for the GenerateDownload Lambda function, so we can lock down permissions for the KMS keys used for a cross-account queue