### PR TITLE
Send audit timestamp in seconds, not seconds

### DIFF
--- a/src/lambdas/confirmDownload/auditTemporaryS3LinkCreated.spec.ts
+++ b/src/lambdas/confirmDownload/auditTemporaryS3LinkCreated.spec.ts
@@ -1,8 +1,8 @@
 import { sendSqsMessage } from '../../sharedServices/queue/sendSqsMessage'
-import { currentDateEpochMilliseconds } from '../../utils/currentDateEpochMilliseconds'
+import { currentDateEpochSeconds } from '../../utils/currentDateEpoch'
 import {
   TEST_AUDIT_DATA_REQUEST_EVENTS_QUEUE_URL,
-  TEST_CURRENT_TIME_EPOCH_MILLISECONDS,
+  TEST_CURRENT_TIME_EPOCH_SECONDS,
   TEST_ZENDESK_TICKET_ID
 } from '../../utils/tests/setup/testConstants'
 import { auditTemporaryS3LinkCreated } from './auditTemporaryS3LinkCreated'
@@ -12,8 +12,8 @@ jest.mock('../../sharedServices/queue/sendSqsMessage', () => ({
   sendSqsMessage: jest.fn()
 }))
 
-jest.mock('../../utils/currentDateEpochMilliseconds', () => ({
-  currentDateEpochMilliseconds: jest.fn()
+jest.mock('../../utils/currentDateEpoch', () => ({
+  currentDateEpochSeconds: jest.fn()
 }))
 
 describe('auditTemporaryS3LinkCreated', () => {
@@ -21,15 +21,13 @@ describe('auditTemporaryS3LinkCreated', () => {
     jest.spyOn(global.console, 'error')
   })
 
-  when(currentDateEpochMilliseconds).mockReturnValue(
-    TEST_CURRENT_TIME_EPOCH_MILLISECONDS
-  )
+  when(currentDateEpochSeconds).mockReturnValue(TEST_CURRENT_TIME_EPOCH_SECONDS)
 
   it('should send an audit message in the right format', async () => {
     await auditTemporaryS3LinkCreated(TEST_ZENDESK_TICKET_ID)
     expect(sendSqsMessage).toHaveBeenCalledWith(
       {
-        timestamp: TEST_CURRENT_TIME_EPOCH_MILLISECONDS,
+        timestamp: TEST_CURRENT_TIME_EPOCH_SECONDS,
         event_name: 'TXMA_AUDIT_QUERY_OUTPUT_ACCESSED',
         component_id: 'TXMA',
         extensions: {

--- a/src/lambdas/confirmDownload/auditTemporaryS3LinkCreated.ts
+++ b/src/lambdas/confirmDownload/auditTemporaryS3LinkCreated.ts
@@ -1,12 +1,12 @@
 import { sendSqsMessage } from '../../sharedServices/queue/sendSqsMessage'
-import { currentDateEpochMilliseconds } from '../../utils/currentDateEpochMilliseconds'
+import { currentDateEpochSeconds } from '../../utils/currentDateEpoch'
 import { getEnv } from '../../utils/getEnv'
 
 export const auditTemporaryS3LinkCreated = async (zendeskId: string) => {
   try {
     await sendSqsMessage(
       {
-        timestamp: currentDateEpochMilliseconds(),
+        timestamp: currentDateEpochSeconds(),
         event_name: 'TXMA_AUDIT_QUERY_OUTPUT_ACCESSED',
         component_id: 'TXMA',
         extensions: {

--- a/src/lambdas/generateDownload/writeOutSecureDownloadRecord.spec.ts
+++ b/src/lambdas/generateDownload/writeOutSecureDownloadRecord.spec.ts
@@ -11,12 +11,12 @@ import {
   TEST_QUERY_RESULTS_BUCKET_NAME,
   TEST_ZENDESK_TICKET_ID
 } from '../../utils/tests/setup/testConstants'
-import { currentDateEpochMilliseconds } from '../../utils/currentDateEpochMilliseconds'
+import { currentDateEpochMilliseconds } from '../../utils/currentDateEpoch'
 import { writeOutSecureDownloadRecord } from './writeOutSecureDownloadRecord'
 import { when } from 'jest-when'
 import 'aws-sdk-client-mock-jest'
 
-jest.mock('../../utils/currentDateEpochMilliseconds', () => ({
+jest.mock('../../utils/currentDateEpoch', () => ({
   currentDateEpochMilliseconds: jest.fn()
 }))
 

--- a/src/lambdas/generateDownload/writeOutSecureDownloadRecord.ts
+++ b/src/lambdas/generateDownload/writeOutSecureDownloadRecord.ts
@@ -1,6 +1,6 @@
 import { PutItemCommand, PutItemCommandInput } from '@aws-sdk/client-dynamodb'
 import { ddbClient } from '../../sharedServices/dynamoDb/dynamoDbClient'
-import { currentDateEpochMilliseconds } from '../../utils/currentDateEpochMilliseconds'
+import { currentDateEpochMilliseconds } from '../../utils/currentDateEpoch'
 import { getEnv } from '../../utils/getEnv'
 
 export const writeOutSecureDownloadRecord = async (parameters: {

--- a/src/sharedServices/getDownloadAvailabilityResult.spec.ts
+++ b/src/sharedServices/getDownloadAvailabilityResult.spec.ts
@@ -17,7 +17,7 @@ jest.mock('./isDateOverDaysLimit', () => ({
 jest.mock('./dynamoDb/getSecureDownloadRecord', () => ({
   getSecureDownloadRecord: jest.fn()
 }))
-jest.mock('../utils/currentDateEpochMilliseconds', () => ({
+jest.mock('../utils/currentDateEpoch', () => ({
   currentDateEpochMilliseconds: jest.fn()
 }))
 

--- a/src/sharedServices/isDateOverDaysLimit.spec.ts
+++ b/src/sharedServices/isDateOverDaysLimit.spec.ts
@@ -1,7 +1,7 @@
 import { isDateOverDaysLimit } from './isDateOverDaysLimit'
-import { currentDateEpochMilliseconds } from '../utils/currentDateEpochMilliseconds'
+import { currentDateEpochMilliseconds } from '../utils/currentDateEpoch'
 import { when } from 'jest-when'
-jest.mock('../utils/currentDateEpochMilliseconds', () => ({
+jest.mock('../utils/currentDateEpoch', () => ({
   currentDateEpochMilliseconds: jest.fn()
 }))
 

--- a/src/sharedServices/isDateOverDaysLimit.ts
+++ b/src/sharedServices/isDateOverDaysLimit.ts
@@ -1,4 +1,4 @@
-import { currentDateEpochMilliseconds } from '../utils/currentDateEpochMilliseconds'
+import { currentDateEpochMilliseconds } from '../utils/currentDateEpoch'
 
 export const isDateOverDaysLimit = (
   date: number,

--- a/src/utils/currentDateEpoch.ts
+++ b/src/utils/currentDateEpoch.ts
@@ -1,0 +1,3 @@
+export const currentDateEpochMilliseconds = (): number => Date.now()
+export const currentDateEpochSeconds = (): number =>
+  Math.round(currentDateEpochMilliseconds() / 1000)

--- a/src/utils/currentDateEpochMilliseconds.ts
+++ b/src/utils/currentDateEpochMilliseconds.ts
@@ -1,1 +1,0 @@
-export const currentDateEpochMilliseconds = (): number => Date.now()

--- a/src/utils/tests/setup/testConstants.ts
+++ b/src/utils/tests/setup/testConstants.ts
@@ -11,7 +11,7 @@ export const TEST_ZENDESK_TICKET_ID = '1234'
 export const TEST_AUDIT_DATA_REQUEST_EVENTS_QUEUE_URL =
   'http://audit-data-request-events-queue'
 export const TEST_CURRENT_TIME_EPOCH_MILLISECONDS = 1667836126
-
+export const TEST_CURRENT_TIME_EPOCH_SECONDS = 1667836
 export const TEST_ATHENA_QUERY_ID = 'myAthenaQueryId'
 export const TEST_RECIPIENT_EMAIL = 'myemail@test.gov.uk'
 export const TEST_RECIPIENT_NAME = 'My test recipient name'


### PR DESCRIPTION
After integration with TxMA1, it was discovered that they expected the timestamp to be in seconds rather than milliseconds