### PR TITLE
Add dependabot config file

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: dependabot
+      include: scope


### PR DESCRIPTION
* Run dependabot scan daily and prefix PR titles with "dependabot: "
* Note: package-ecosystem: npm also applies to Yarn - see https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem