### PR TITLE
Ignore AWS SDK updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -11,3 +11,4 @@ updates:
       - dependency-name: '*'
         update-types:
           - version-update:semver-major
+      - dependency-name: '@aws-sdk/*'


### PR DESCRIPTION
Have dependabot ignore AWS SDK updates as these are quite noisy, and sometime they break our builds.