### PR TITLE
Remove unused lamba code from each package

### DIFF
--- a/esbuild.config.ts
+++ b/esbuild.config.ts
@@ -9,11 +9,11 @@ interface IAwsResource {
 
 interface ILambdaFunction extends IAwsResource {
   Properties: {
-    Handler: string
+    CodeUri: string
   }
 }
 
-const handlerPath = 'src/lambdas'
+const lambdasPath = 'src/lambdas'
 
 const { Resources } = yamlParse(
   readFileSync(join(__dirname, 'template.yaml'), 'utf-8')
@@ -25,13 +25,10 @@ const lambdas = awsResources.filter(
   (resource) => resource.Type === 'AWS::Serverless::Function'
 ) as ILambdaFunction[]
 
-const entries = lambdas.reduce((entries, lambda) => {
-  const handlerName = lambda.Properties.Handler.split('.')[0]
-  const filepath = `./${handlerPath}/${handlerName}/handler.ts`
-
-  entries[handlerName] = filepath
-  return entries
-}, {} as { [key: string]: string })
+const entries = lambdas.map((lambda) => {
+  const lambdaName = lambda.Properties.CodeUri.split('/')[1]
+  return `./${lambdasPath}/${lambdaName}/handler.ts`
+})
 
 esbuild
   .build({

--- a/template.yaml
+++ b/template.yaml
@@ -52,7 +52,6 @@ Globals:
   Function:
     CodeSigningConfigArn:
       !If [UseCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue]
-    CodeUri: dist/
     Environment:
       Variables:
         NODE_OPTIONS: --enable-source-maps
@@ -131,7 +130,8 @@ Resources:
     #checkov:skip=CKV_AWS_117:VPC not required
     Type: AWS::Serverless::Function
     Properties:
-      Handler: confirmDownload.handler
+      CodeUri: dist/confirmDownload/
+      Handler: handler.handler
       Environment:
         Variables:
           SECURE_DOWNLOAD_TABLE_NAME: '{{resolve:ssm:SecureFraudSiteDataTableName}}'
@@ -205,7 +205,8 @@ Resources:
     #checkov:skip=CKV_AWS_117:VPC not required
     Type: AWS::Serverless::Function
     Properties:
-      Handler: downloadWarning.handler
+      CodeUri: dist/downloadWarning/
+      Handler: handler.handler
       Environment:
         Variables:
           SECURE_DOWNLOAD_TABLE_NAME: '{{resolve:ssm:SecureFraudSiteDataTableName}}'
@@ -260,7 +261,8 @@ Resources:
     #checkov:skip=CKV_AWS_117:VPC not required
     Type: AWS::Serverless::Function
     Properties:
-      Handler: sendEmailRequestToNotify.handler
+      CodeUri: dist/sendEmailRequestToNotify/
+      Handler: handler.handler
       Environment:
         Variables:
           ENVIRONMENT: !Ref Environment
@@ -348,7 +350,8 @@ Resources:
     #checkov:skip=CKV_AWS_116:Queue we read from has DLQ set up
     Type: AWS::Serverless::Function
     Properties:
-      Handler: generateDownload.handler
+      CodeUri: dist/generateDownload/
+      Handler: handler.handler
       Role: !GetAtt GenerateDownloadFunctionRole.Arn
       Environment:
         Variables:


### PR DESCRIPTION
* Update ESBuild config to build into different folders within `dist/`
* Update template so each function now has its own CodeUri property, and update handler path to match what ESBuild does