### PR TITLE
Feature/tt2 471 add security headers

### DIFF
--- a/src/lambdas/confirmDownload/handler.test.ts
+++ b/src/lambdas/confirmDownload/handler.test.ts
@@ -14,6 +14,7 @@ import {
   TEST_ZENDESK_TICKET_ID
 } from '../../utils/tests/setup/testConstants'
 import { mockLambdaContext } from '../../utils/tests/mocks/mockLambdaContext'
+import { assertSecurityHeadersSet } from '../../utils/tests/assertSecurityHeadersSet'
 
 jest.mock('../../sharedServices/getDownloadAvailabilityResult', () => ({
   getDownloadAvailabilityResult: jest.fn()
@@ -75,6 +76,9 @@ describe('confirmDownload.handler', () => {
     const result = await handler(defaultApiRequest, mockLambdaContext)
     expect(result.statusCode).toEqual(400)
     expect(result.body).toBe('')
+
+    assertSecurityHeadersSet(result)
+
     expect(getDownloadAvailabilityResult).not.toHaveBeenCalled()
   })
 
@@ -84,6 +88,9 @@ describe('confirmDownload.handler', () => {
 
     expect(result.statusCode).toEqual(500)
     expect(result.body).toBe('')
+
+    assertSecurityHeadersSet(result)
+
     expect(getDownloadAvailabilityResult).toHaveBeenCalledWith(DOWNLOAD_HASH)
     expect(logger.error).toHaveBeenCalledWith(
       'Error while handling confirm download request',
@@ -97,6 +104,9 @@ describe('confirmDownload.handler', () => {
 
     expect(result.statusCode).toEqual(404)
     expect(result.body).toBe('')
+
+    assertSecurityHeadersSet(result)
+
     expect(getDownloadAvailabilityResult).toHaveBeenCalledWith(DOWNLOAD_HASH)
     expect(logger.warn).toHaveBeenCalledWith(
       'Returning 404 response because no record was found'
@@ -109,6 +119,9 @@ describe('confirmDownload.handler', () => {
 
     expect(result.statusCode).toEqual(404)
     expect(result.body).toBe('')
+
+    assertSecurityHeadersSet(result)
+
     expect(getDownloadAvailabilityResult).toHaveBeenCalledWith(DOWNLOAD_HASH)
     expect(logger.warn).toHaveBeenCalledWith(
       'Returning 404 response because the download has expired or has been downloaded too many times already'
@@ -125,6 +138,9 @@ describe('confirmDownload.handler', () => {
     expect(result.body).toContain(
       `<meta http-equiv="refresh" content="0; url=${TEST_SIGNED_URL}">`
     )
+
+    assertSecurityHeadersSet(result)
+
     expect(createTemporaryS3Link).toHaveBeenCalledWith({
       bucket: TEST_QUERY_RESULTS_BUCKET_NAME,
       key: TEST_S3_OBJECT_KEY
@@ -142,5 +158,7 @@ describe('confirmDownload.handler', () => {
     expect(result.body).toContain(
       'Your data will automatically download in CSV format.'
     )
+
+    assertSecurityHeadersSet(result)
   })
 })

--- a/src/lambdas/downloadWarning/handler.test.ts
+++ b/src/lambdas/downloadWarning/handler.test.ts
@@ -10,6 +10,7 @@ import {
   TEST_ZENDESK_TICKET_ID
 } from '../../utils/tests/setup/testConstants'
 import { mockLambdaContext } from '../../utils/tests/mocks/mockLambdaContext'
+import { assertSecurityHeadersSet } from '../../utils/tests/assertSecurityHeadersSet'
 
 jest.mock('../../sharedServices/getDownloadAvailabilityResult', () => ({
   getDownloadAvailabilityResult: jest.fn()
@@ -70,6 +71,9 @@ describe('downloadWarning.handler', () => {
 
     expect(result.statusCode).toEqual(500)
     expect(result.body).toBe('')
+
+    assertSecurityHeadersSet(result)
+
     expect(getDownloadAvailabilityResult).toHaveBeenCalledWith(DOWNLOAD_HASH)
     expect(logger.error).toHaveBeenCalledWith(
       'Error while handling download warning request',
@@ -83,6 +87,9 @@ describe('downloadWarning.handler', () => {
 
     expect(result.statusCode).toEqual(404)
     expect(result.body).toBe('')
+
+    assertSecurityHeadersSet(result)
+
     expect(getDownloadAvailabilityResult).toHaveBeenCalledWith(DOWNLOAD_HASH)
     expect(logger.warn).toHaveBeenCalledWith(
       'Returning 404 response because no record was found'
@@ -95,6 +102,9 @@ describe('downloadWarning.handler', () => {
 
     expect(result.statusCode).toEqual(404)
     expect(result.body).toBe('')
+
+    assertSecurityHeadersSet(result)
+
     expect(getDownloadAvailabilityResult).toHaveBeenCalledWith(DOWNLOAD_HASH)
     expect(logger.warn).toHaveBeenCalledWith(
       'Returning 404 response because the download has expired or has been downloaded too many times already'
@@ -107,6 +117,9 @@ describe('downloadWarning.handler', () => {
 
     expect(getDownloadAvailabilityResult).toHaveBeenCalledWith(DOWNLOAD_HASH)
     expect(result.statusCode).toEqual(200)
+
+    assertSecurityHeadersSet(result)
+
     expect(result.body).toContain('Download the report')
     expect(result.body).toContain(
       `You have ${TEST_DOWNLOADS_REMAINING} downloads remaining.`

--- a/src/sharedServices/responseHelpers.ts
+++ b/src/sharedServices/responseHelpers.ts
@@ -1,3 +1,4 @@
+import { APIGatewayProxyResult } from 'aws-lambda'
 import { logger } from './logger'
 
 export const notFoundResponse = (recordWasFound: boolean) => {
@@ -23,18 +24,30 @@ export const invalidParametersResponse = () => {
 }
 
 export const htmlResponse = (statusCode: number, body: string) => {
-  return {
+  return appendSecurityHeadersToResponse({
     statusCode: statusCode,
     body: body,
     headers: {
       'Content-type': 'text/html'
     }
-  }
+  })
 }
 
 export const emptyStatusCodeResponse = (statusCode: number) => {
-  return {
+  return appendSecurityHeadersToResponse({
     statusCode,
     body: ''
+  })
+}
+
+const appendSecurityHeadersToResponse = (
+  response: APIGatewayProxyResult
+): APIGatewayProxyResult => {
+  if (!response.headers) {
+    response.headers = {}
   }
+  response.headers['Strict-Transport-Security'] =
+    'max-age=31536000; includeSubDomains; preload'
+  response.headers['X-Frame-Options'] = 'DENY'
+  return response
 }

--- a/src/utils/tests/assertSecurityHeadersSet.ts
+++ b/src/utils/tests/assertSecurityHeadersSet.ts
@@ -1,0 +1,9 @@
+import { APIGatewayProxyResult } from 'aws-lambda'
+
+export const assertSecurityHeadersSet = (result: APIGatewayProxyResult) => {
+  expect(result.headers && result.headers['Strict-Transport-Security']).toEqual(
+    'max-age=31536000; includeSubDomains; preload'
+  )
+
+  expect(result.headers && result.headers['X-Frame-Options']).toEqual('DENY')
+}

--- a/template.yaml
+++ b/template.yaml
@@ -88,9 +88,6 @@ Resources:
       EndpointConfiguration:
         Type: REGIONAL
       GatewayResponses:
-        default:
-          responseParameters:
-            gatewayresponse.header.Strict-Transport-Security:: 'max-age=31536000; includeSubDomains; preload'
         ACCESS_DENIED:
           ResponseTemplates:
             application/json: '{"message": "Access Denied: if you think you should have access to this URL, make sure you are connected to the VPN"}'

--- a/template.yaml
+++ b/template.yaml
@@ -88,6 +88,9 @@ Resources:
       EndpointConfiguration:
         Type: REGIONAL
       GatewayResponses:
+        default:
+          responseParameters:
+            gatewayresponse.header.Strict-Transport-Security:: 'max-age=31536000; includeSubDomains; preload'
         ACCESS_DENIED:
           ResponseTemplates:
             application/json: '{"message": "Access Denied: if you think you should have access to this URL, make sure you are connected to the VPN"}'

--- a/tests/integration-tests/test-suites/downloadPages.spec.ts
+++ b/tests/integration-tests/test-suites/downloadPages.spec.ts
@@ -36,6 +36,7 @@ describe('Download pages', () => {
     // Download 1
     const firstGetResponse = await sendRequest(downloadUrl, 'GET')
     expect(firstGetResponse.status).toEqual(200)
+    assertSecurityHeadersSet(firstGetResponse)
     const contentType = firstGetResponse.headers['content-type']
     expect(contentType).toEqual('text/html')
     expect(firstGetResponse.data).toContain('Download the report')
@@ -66,6 +67,7 @@ describe('Download pages', () => {
     assertDownloadNotFoundResponse(thirdGetResponse)
     const thirdDownloadResponse = await sendRequest(downloadUrl, 'POST')
     assertDownloadNotFoundResponse(thirdDownloadResponse)
+    assertSecurityHeadersSet(thirdDownloadResponse)
   })
 
   it('API should return a 404 when no record is available for the provided hash', async () => {
@@ -74,10 +76,19 @@ describe('Download pages', () => {
     )}/xxxx-yyyy-zzzz`
     const response = await sendRequest(urlWithNonExistentHash, 'GET')
     assertDownloadNotFoundResponse(response)
+    assertSecurityHeadersSet(response)
   })
 
   const assertDownloadNotFoundResponse = (response: AxiosResponse) => {
     expect(response.status).toEqual(404)
     expect(response.data).toEqual('')
+  }
+
+  const assertSecurityHeadersSet = (result: AxiosResponse) => {
+    expect(
+      result.headers && result.headers['strict-transport-security']
+    ).toEqual('max-age=31536000; includeSubDomains; preload')
+
+    expect(result.headers && result.headers['x-frame-options']).toEqual('DENY')
   }
 })


### PR DESCRIPTION
This PR adds the two standard security headers suggested by the pen test carried out a few months back.

I looked into the possibility of adding these via the API gateway, but couldn't find any way to do it that didn't involve us setting up an OpenAPI definition. Therefore, the solution is simply to add the headers in the Lambda handler. Since we're generating our responses in a centralised way, it was fairly easy to do this without too many code changes.